### PR TITLE
Fix mic mute not silencing capture on drivers that ignore the endpoint mute flag

### DIFF
--- a/src/main_parts/audio.rs
+++ b/src/main_parts/audio.rs
@@ -201,13 +201,10 @@ fn set_mute_to_inverse(device_id: Option<&str>) -> Result<bool> {
         set_all_capture_devices_mute(next)?;
         return Ok(next);
     }
-    let volume = target_capture_volume(device_id)?;
-    unsafe {
-        let muted = volume.GetMute()?;
-        let next = !muted.as_bool();
-        volume.SetMute(next, null())?;
-        Ok(next)
-    }
+    let (volume, id) = capture_volume_with_id(device_id.filter(|id| !id.is_empty()))?;
+    let next = unsafe { !volume.GetMute()?.as_bool() };
+    apply_capture_mute(&volume, &id, next)?;
+    Ok(next)
 }
 
 fn set_mute(device_id: Option<&str>, muted: bool) -> Result<bool> {
@@ -215,11 +212,48 @@ fn set_mute(device_id: Option<&str>, muted: bool) -> Result<bool> {
         set_all_capture_devices_mute(muted)?;
         return Ok(muted);
     }
-    let volume = target_capture_volume(device_id)?;
-    unsafe {
-        volume.SetMute(muted, null())?;
-    }
+    let (volume, id) = capture_volume_with_id(device_id.filter(|id| !id.is_empty()))?;
+    apply_capture_mute(&volume, &id, muted)?;
     Ok(muted)
+}
+
+fn apply_capture_mute(volume: &IAudioEndpointVolume, device_id: &str, muted: bool) -> Result<()> {
+    unsafe {
+        if muted {
+            if !volume.GetMute()?.as_bool() {
+                let scalar = volume.GetMasterVolumeLevelScalar().unwrap_or(1.0);
+                store_premute_capture_volume(device_id, scalar);
+            }
+            volume.SetMute(true, null())?;
+            volume.SetMasterVolumeLevelScalar(0.0, null())?;
+        } else {
+            let restore = take_premute_capture_volume(device_id).or_else(|| {
+                match volume.GetMasterVolumeLevelScalar() {
+                    Ok(current) if current <= f32::EPSILON => Some(1.0),
+                    _ => None,
+                }
+            });
+            volume.SetMute(false, null())?;
+            if let Some(scalar) = restore {
+                volume.SetMasterVolumeLevelScalar(scalar, null())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn store_premute_capture_volume(device_id: &str, scalar: f32) {
+    CAPTURE_PREMUTE_VOLUMES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(device_id.to_string(), scalar);
+}
+
+fn take_premute_capture_volume(device_id: &str) -> Option<f32> {
+    CAPTURE_PREMUTE_VOLUMES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(device_id)
 }
 
 fn hotkey_volume_target_percent(target: Option<&str>, fallback: u8) -> u8 {
@@ -613,8 +647,16 @@ fn is_all_microphones_target(device_id: Option<&str>) -> bool {
     matches!(device_id, Some(id) if id == HOTKEY_TARGET_ALL_MICROPHONES)
 }
 
-fn target_capture_volume(device_id: Option<&str>) -> Result<IAudioEndpointVolume> {
-    capture_volume(device_id.filter(|id| !id.is_empty()))
+fn capture_volume_with_id(device_id: Option<&str>) -> Result<(IAudioEndpointVolume, String)> {
+    unsafe {
+        let enumerator = audio_device_enumerator()?;
+        let device = capture_device(&enumerator, device_id)?;
+        let id = endpoint_device_id(&device)?;
+        let volume = device
+            .Activate(CLSCTX_ALL, None)
+            .context("activate endpoint volume")?;
+        Ok((volume, id))
+    }
 }
 
 fn audio_device_enumerator() -> Result<IMMDeviceEnumerator> {
@@ -663,7 +705,7 @@ unsafe fn capture_device(
         .context("get default capture endpoint")
 }
 
-fn active_capture_device_volumes() -> Result<Vec<IAudioEndpointVolume>> {
+fn active_capture_device_volumes() -> Result<Vec<(String, IAudioEndpointVolume)>> {
     unsafe {
         let enumerator = audio_device_enumerator()?;
         let collection = enumerator
@@ -674,10 +716,11 @@ fn active_capture_device_volumes() -> Result<Vec<IAudioEndpointVolume>> {
 
         for index in 0..count {
             let device = collection.Item(index).context("get capture endpoint")?;
+            let id = endpoint_device_id(&device)?;
             let volume = device
                 .Activate(CLSCTX_ALL, None)
                 .context("activate endpoint volume")?;
-            volumes.push(volume);
+            volumes.push((id, volume));
         }
 
         Ok(volumes)
@@ -685,10 +728,8 @@ fn active_capture_device_volumes() -> Result<Vec<IAudioEndpointVolume>> {
 }
 
 fn set_all_capture_devices_mute(muted: bool) -> Result<()> {
-    for volume in active_capture_device_volumes()? {
-        unsafe {
-            volume.SetMute(muted, null())?;
-        }
+    for (id, volume) in active_capture_device_volumes()? {
+        apply_capture_mute(&volume, &id, muted)?;
     }
     Ok(())
 }

--- a/src/main_parts/globals.rs
+++ b/src/main_parts/globals.rs
@@ -23,6 +23,8 @@ static TRAY_DEVICE_COMMANDS: Lazy<Mutex<HashMap<usize, TrayDeviceCommand>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 static NORMALIZED_AUDIO_DEVICE_NAMES: Lazy<Mutex<HashSet<(String, String)>>> =
     Lazy::new(|| Mutex::new(HashSet::new()));
+static CAPTURE_PREMUTE_VOLUMES: Lazy<Mutex<HashMap<String, f32>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 static PENDING_NOTIFICATION_ACTION: Lazy<Mutex<Option<NotificationAction>>> =
     Lazy::new(|| Mutex::new(None));
 static SETTINGS_ORIGINAL_WNDPROC: AtomicIsize = AtomicIsize::new(0);


### PR DESCRIPTION
## Problem
https://github.com/vertopolkaLF/silence/issues/60
On some systems (reported on Windows 10 22H2, build 19045) muting the
microphone via the tray/mic icon does not actually silence the capture —
apps keep hearing the mic. Windows shows the device as muted and
`GetMute()` returns `true`, but the samples keep flowing. Manually
dragging the Windows mic volume slider to 0 reliably silences it.

## Cause
Mute was applied only through `IAudioEndpointVolume::SetMute()`. A number
of capture drivers report the endpoint mute state to the OS UI but never
gate the stream that applications receive, so the mute flag alone is not
enough. Forcing the master volume scalar to zero is applied inside the
audio engine mixer and cannot be bypassed.

## Fix
All mute paths (`set_mute`, `set_mute_to_inverse`, per-device and
"all microphones") now go through a single `apply_capture_mute()` that:

- **On mute:** saves the current volume scalar (only on the
  unmuted→muted transition, so re-muting doesn't overwrite it with the
  forced 0), then `SetMute(true)` **and** `SetMasterVolumeLevelScalar(0.0)`.
- **On unmute:** restores the saved scalar and `SetMute(false)`.

The pre-mute level is kept per-device in a new `CAPTURE_PREMUTE_VOLUMES`
map.

Mute-state tracking is unchanged — everything still reads `GetMute()`,
which is still set, so tray/overlay/notifications stay correct. The
volume-change notification just re-reads `GetMute()`; no feedback loop.

## Edge cases
- **Restart while muted:** the in-memory map is empty, so on unmute, if
  the level is still 0 it's restored to 100% instead of leaving the mic
  dead. Worst case is "unmutes to full volume", never a silent mic.
- Works for hotkey mute/unmute and the "all microphones" target (same code path).

## Testing
- `cargo check` passes (no new warnings).
- Manually: mute via tray → mic silent in Voice Recorder / Sound
  settings level meter / Discord mic test → unmute restores audio and
  the previous volume level.